### PR TITLE
include events next/prev buttons also on top

### DIFF
--- a/app/events/index.html
+++ b/app/events/index.html
@@ -21,6 +21,14 @@ title: Events
     </div>
 </div>
 </script>
+<ul class="pager">
+    <li class="previous">
+        <a href="">&larr; vorheriger Monat</a>
+    </li>
+    <li class="next">
+        <a href="">nächster Monat &rarr;</a>
+    </li>
+</ul>
 <div id="rzl-events"></div>
 <ul class="pager">
     <li class="previous">


### PR DESCRIPTION
Wenn man schnell zu einem Monat will sind prev/next Buttons auch oben vielleicht ganz sinnvoll.
In Zukunft wird unser Eventkalender natürlich elend lange scrollen wegen der tausenden cooler Events die wir haben, deshalb Buttons auch oben!
[nicht getestet, ob das so passt ;oP]