### PR TITLE
Text-Rendering-Verbesserungen

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -297,3 +297,9 @@ display:block;
 margin-top:-27%;
 }
 
+/* Disable text-align: justify for YouTube video archive descriptions as
+ * they're usually rather short text snippets which look weird justified */
+.rzl-content #youtube-archive {
+        text-align: left; /* Internet Explorer */
+        text-align: start;
+}

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -14,6 +14,7 @@ font-family: 'Miso';
 }
 
 .rzl-body {
+text-rendering: optimizeLegibility;
 }
 
 .rzl-nav {


### PR DESCRIPTION
Dieser PR
* setzt text-rendering auf optimizeLegibility. Das sorgt in Firefox und Chrome dafür dass sie vernünftiges Kerning machen und Ligaturen rendern und generell alles schöner ist. Das ist etwas buggy in alten Browserversionen und in Kombination mit Windows XP oder so, aber das ist glaube ich bei unserer Zielgruppe vernachlässigbar.
* Macht Justification für die Youtube-Video-Beschreibungen aus, weil das immer nur kurze Textsnippets sind bei denen das komisch aussieht:

![2015-01-31-193330_607x420_scrot](https://cloud.githubusercontent.com/assets/179393/5989223/1065c0fa-a980-11e4-8a42-9ffe00e4e3fa.png)

