### PR TITLE
Add sitemap.xml

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,12 @@ module.exports = function (grunt) {
                 tasks: ['newer:copy:styles', 'autoprefixer']
             },
             jekyll: {
-                files: ['<%= config.app %>/**/*.html', '<%= config.app %>/feed.xml', '_config.yml'],
+                files: [
+                    '<%= config.app %>/**/*.html',
+                    '<%= config.app %>/feed.xml',
+                    '<%= config.app %>/sitemap.xml',
+                    '_config.yml'
+                ],
                 tasks: ['clean:dist', 'copy:jekyll', 'autoprefixer', 'jekyll:dist', 'copy:build'],
             },
             livereload: {
@@ -332,7 +337,7 @@ module.exports = function (grunt) {
                     dot: false,
                     cwd: '<%= config.app %>',
                     dest: '<%= config.jekyll %>',
-                    src: ['**/*.html', 'feed.xml']
+                    src: ['**/*.html', 'feed.xml', 'sitemap.xml']
                 }]
             },
             dist: {
@@ -368,7 +373,7 @@ module.exports = function (grunt) {
                     dot: false,
                     cwd: '.tmp/jekyll',
                     dest: '<%= config.dist %>',
-                    src: ['**/*.html', 'feed.xml']
+                    src: ['**/*.html', 'feed.xml', 'sitemap.xml']
                 }, {
                     expand: true,
                     dot: false,

--- a/app/sitemap.xml
+++ b/app/sitemap.xml
@@ -1,0 +1,56 @@
+---
+layout: null
+sitemap:
+  exclude: 'yes'
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for post in site.posts %}
+    {% unless post.published == false %}
+    <url>
+      <loc>{{ site.url }}{{ post.url }}</loc>
+      {% if post.sitemap.lastmod %}
+        <lastmod>{{ post.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+      {% elsif post.date %}
+        <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+      {% else %}
+        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+      {% endif %}
+      {% if post.sitemap.changefreq %}
+        <changefreq>{{ post.sitemap.changefreq }}</changefreq>
+      {% else %}
+        <changefreq>monthly</changefreq>
+      {% endif %}
+      {% if post.sitemap.priority %}
+        <priority>{{ post.sitemap.priority }}</priority>
+      {% else %}
+        <priority>0.5</priority>
+      {% endif %}
+    </url>
+    {% endunless %}
+  {% endfor %}
+  {% for page in site.pages %}
+    {% unless page.sitemap.exclude == "yes" %}
+    <url>
+      <loc>{{ site.url }}{{ page.url | remove: "index.html" }}</loc>
+      {% if page.sitemap.lastmod %}
+        <lastmod>{{ page.sitemap.lastmod | date: "%Y-%m-%d" }}</lastmod>
+      {% elsif page.date %}
+        <lastmod>{{ page.date | date_to_xmlschema }}</lastmod>
+      {% else %}
+        <lastmod>{{ site.time | date_to_xmlschema }}</lastmod>
+      {% endif %}
+      {% if page.sitemap.changefreq %}
+        <changefreq>{{ page.sitemap.changefreq }}</changefreq>
+      {% else %}
+        <changefreq>monthly</changefreq>
+      {% endif %}
+      {% if page.sitemap.priority %}
+        <priority>{{ page.sitemap.priority }}</priority>
+      {% else %}
+        <priority>0.3</priority>
+      {% endif %}
+    </url>
+    {% endunless %}
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
Closes raumzeitlabor/rzl-homepage#31.

To be honest, I have no idea what I'm doing here, but I took the template
described in [1] and somehow got grunt to process it.

The defaults for entries in the sitemap.xml are for pages:

    priority: 0.3
    changefreq: monthly

The defaults for entries in the sitemap.xml are for blog posts:

    priority: 0.5
    changefreq: monthly

These defaults can be overridden in the front matter by adding following
variables (exclude is only supported for pages):

    sitemap:
        lastmod: 2014-01-23
        priority: 0.7
        changefreq: 'monthly'
        exclude: 'yes'

[1]: http://davidensinger.com/2013/11/building-a-better-sitemap-xml-with-jekyll/
(Do we have a place for credits like these?)