### PR TITLE
change headings to be unjustified

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -11,6 +11,8 @@ src: url(/fonts/miso-bold.otf) format('opentype');
 
 .rzl-content h1, .rzl-content h2, .rzl-content h3 {
 font-family: 'Miso';
+text-align: left; /* Internet Explorer */
+text-align: start;
 }
 
 .rzl-body {


### PR DESCRIPTION
in mobile view, the titles of blog posts look ugly because they are justified.
When in Landscape or on a desktop, no one cares because Post titles mostly stay in one line...