### PR TITLE
Fix layout for kontakt/anfahrt

### DIFF
--- a/app/kontakt/anfahrt/index.html
+++ b/app/kontakt/anfahrt/index.html
@@ -33,21 +33,14 @@ htmlheader: <link rel="stylesheet" href="/bower_components/leaflet/dist/leaflet.
         </div>
         <div class="stepdescr" id="step3" style="display:none;">
             <p>Du solltest jetzt am Alstom Gelände vorbei sein und vor dem großen Tor an der Spedition Kübler stehen. Wenn Du den Briefkasten des RaumZeitLabor gefunden hast, bist Du auf jedenfall richtig.</p>
-            <p>Jetzt gibt es mehrere Möglichkeiten: Entweder das Tor ist
-                <ul style="list-style-type:lower-alpha;padding-left:15%">
-                    <li>
-                        <ul class="pager" style="margin-top:-20px;margin-bottom:5px;">
-                            <li class="next"><em>offen</em>, oder<span style="float:right"><a href="#step5">weiter →</a></span></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <ul class="pager" style="margin-top:-20px;margin-bottom:0">
-                            <li class="next"><em>geschlossen</em>.<span style="float:right"><a href="#step4">weiter →</a></span></li>
-                        </ul>
-                    </li>
-                </ul>
-                So oder so, es ist nicht mehr weit!
-            </p>
+            <p>Jetzt gibt es mehrere Möglichkeiten: Entweder das Tor ist offen oder geschlossen.</p>
+            <p>So oder so, es ist nicht mehr weit!</p>
+            <ul class="pager">
+                <li class="next"><span style="float:right"><a href="#step5">Tor ist offen →</a></span></li>
+            </ul>
+            <ul class="pager">
+                <li class="next"><span style="float:right"><a href="#step4">Tor ist geschlossen →</a></span></li>
+            </ul>
             <ul class="pager">
                 <li class="previous"><a href="#step2">&larr; zurück</a></li>
             </ul>


### PR DESCRIPTION


I propose to change the captions of the "next" buttons to reflect the case when they should be clicked ("gate is open" and "gate is closed"). It breaks the consistency of button captions, but makes fragile sorcery like aligning list items of nested lists using negative margins.

For me it looks like a robust and usable tradeoff.

Closes raumzeitlabor/rzl-homepage#13