### PR TITLE
Pin grunt-connect-proxy to 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "time-grunt": "~0.4.0",
     "jshint-stylish": "~0.4.0",
     "grunt-jekyll": "~0.4.2",
-    "grunt-connect-proxy": "~0.1.10",
+    "grunt-connect-proxy": "0.1.10",
     "bower": "~1.3.9",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-copy": "~0.5.0",


### PR DESCRIPTION
The latest version of grunt-connect-proxy (0.1.11) or the underlying http-proxy
is buggy and produces "fatal error: socket hang up" errors when trying to load
events or tumblr images.

Until this is fixed, pin grunt-connect-proxy to the latest working version
(0.1.10).