### PR TITLE
README: Add bundler as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ cache
 app/bower_components
 test/bower_components
 .*.sw[po]
+.bundle/
+Gemfile.lock
+vendor/
 
 deploy_key
 deploy_key.pub

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ own environment. Choose as you like.
 
 #### Requirements
 
-    sudo apt-get install nodejs npm jekyll bundler
+    sudo apt-get install nodejs npm bundler
     sudo npm install -g grunt-cli bower
 
 #### Dependencies
 
     npm install
     export PATH=$PATH:$(npm bin)
+    bundler install --path vendor/bundle
     bower install
 
 #### Hacking

--- a/README.md
+++ b/README.md
@@ -40,8 +40,17 @@ own environment. Choose as you like.
 
 #### Requirements
 
+##### Debian
+
     sudo apt-get install nodejs npm bundler
     sudo npm install -g grunt-cli bower
+
+##### FreeBSD
+
+    sudo pkg install node npm rubygem-bundler nasm
+    sudo npm install -g grunt-cli bower
+
+*Note: nasm(1) is needed to compile some node packages from source.*
 
 #### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ own environment. Choose as you like.
 
 #### Requirements
 
-    sudo apt-get install nodejs npm jekyll
+    sudo apt-get install nodejs npm jekyll bundler
     sudo npm install -g grunt-cli bower
 
 #### Dependencies


### PR DESCRIPTION
Starting with 6fdf25f6ac70223e45c544bb497a3c5e6e4e642e this project depends on
`bundler`. Document this dependency in the README.md.

CAVEAT: As I am using FreeBSD I am not totally sure that the Debian package is
really called `bundler` although packages.debian.org suggests that my edit is
correct.