### PR TITLE
Events: Improve layout on small screens

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -284,6 +284,16 @@ text-align:center;
 text-transform:uppercase;
 }
 
+@media(max-width:980px) {
+.rzl-event-wrap {
+margin-bottom:55px;
+}
+
+.rzl-event-date {
+margin-top:-50px;
+}
+}
+
 .rzl-event-name {
 margin:0.25em 0;
 }


### PR DESCRIPTION
Don't let the date overlap the event on small screens.

Fixes raumzeitlabor/rzl-homepage#33