### PR TITLE
Events: Scroll back to top when new month loaded

### DIFF
--- a/app/scripts/events.js
+++ b/app/scripts/events.js
@@ -128,5 +128,6 @@
 
     $(window).on('hashchange', function() {
         loadEvents();
+        $('html,body').animate({scrollTop: $('#rzl-events').offset().top},'slow');
     });
 })();


### PR DESCRIPTION
Nachdem der Kalender geladen wurde (z.B. weil man auf den nächsten Monat geblättert hat), wird man nun mit einer Animation wieder an den Anfang des Kalenders gesetzt.