### PR TITLE
Blog: Fix markdown for blogpost pages

### DIFF
--- a/app/_includes/blogpost.html
+++ b/app/_includes/blogpost.html
@@ -1,7 +1,7 @@
 <div class="col-lg-9 col-md-8 col-sm-7 col-xs-12 rzl-blogpost">
     <h2><a href="{{ include.blogpost.url }}">{{ include.blogpost.title }}</a></h2>
     <p class="rzl-blogpost-date">veröffentlicht am {{ include.blogpost.date | date: "%-d." }} {% assign m = include.blogpost.date | date: "%-m" %}{% case m %}{% when '1' %}Januar {% when '2' %}Februar {% when '3' %}M&auml;rz {% when '4' %}April {% when '5' %}Mai {% when '6' %}Juni {% when '7' %}Juli {% when '8' %}August {% when '9' %}September {% when '10' %}Oktober {% when '11' %}November {% when '12' %}Dezember {% endcase %}{{ include.blogpost.date | date: "%Y" }}</p>
-    <p>{{ include.blogpost.content }}</p>
+    <p>{{ include.blogpost.content | markdownify }}</p>
 </div>
 {% capture loginname %}{{ include.blogpost.author.login | downcase }}{% endcapture %}
 <div class="col-lg-3 col-md-4 col-sm-5 col-xs-12 rzl-blogpost-meta">


### PR DESCRIPTION
The index of the blog looked fine, but if you followed a permalink to a post
by clicking the post header, you were presented the raw markdown in the blogpost
page.