### PR TITLE
Let git generate commit SHA-1 ID on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+app/CHANGELOG.json ident

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,8 +18,6 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-jekyll');
     grunt.loadNpmTasks('grunt-connect-proxy');
     grunt.loadNpmTasks('grunt-contrib-copy');
-    grunt.loadNpmTasks('grunt-git-describe');
-    grunt.loadNpmTasks('grunt-text-replace');
 
     // Define the configuration for all the tasks
     grunt.initConfig({
@@ -71,7 +69,6 @@ module.exports = function (grunt) {
                     'autoprefixer',
                     'jekyll:dist',
                     'copy:build',
-                    'saveRevision'
                 ],
             },
             livereload: {
@@ -457,31 +454,6 @@ module.exports = function (grunt) {
                 }
             }
         },
-
-        'git-describe': {
-            'full': {
-            }
-        },
-
-        replace: {
-            gitversion: {
-                src: ['<%= config.dist %>/CHANGELOG.json'],
-                overwrite: true,
-                replacements: [{
-                    from: 'GIT_VERSION_INFO',
-                    to: function() {
-                        return grunt.option('gitRevision');
-                    }
-                }]
-            }
-        }
-    });
-
-    grunt.registerTask('saveRevision', function() {
-        grunt.event.once('git-describe', function (rev) {
-            grunt.option('gitRevision', rev);
-        });
-        grunt.task.run(['git-describe', 'replace']);
     });
 
     grunt.registerTask('serve', function (target) {
@@ -499,7 +471,6 @@ module.exports = function (grunt) {
             'autoprefixer',
             'jekyll:dist',
             'copy:build',
-            'saveRevision',
 
             'configureProxies',
             'connect:livereload',
@@ -541,7 +512,6 @@ module.exports = function (grunt) {
         'usemin',
         'jekyll:dist',
         'copy:build',
-        'saveRevision',
         'htmlmin'
     ]);
 

--- a/app/CHANGELOG.json
+++ b/app/CHANGELOG.json
@@ -1,1 +1,1 @@
-"GIT_VERSION_INFO"
+"$Id$"

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "grunt-connect-proxy": "0.1.10",
     "bower": "~1.3.9",
     "grunt-cli": "~0.1.13",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-text-replace": "~0.4.0",
-    "grunt-git-describe": "~2.3.2"
+    "grunt-contrib-copy": "~0.5.0"
   },
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
It looks like the grunt-describe-git plugin does not work reliably. This commit picks up blabbers idea (raumzeitlabor/rzl-homepage#51) which I quite liked.