### PR TITLE
Put title in quotation marks

### DIFF
--- a/app/_posts/2015-04-28-mrmcd-call-for-participation.md
+++ b/app/_posts/2015-04-28-mrmcd-call-for-participation.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title: MRMCD 2015: Call for Participation
+title: 'MRMCD 2015: Call for Participation'
 facts:
   Was?: MRMCD
   Wann?: 04.-06.09.2015


### PR DESCRIPTION
The latest post is broken in at least 3 ways:

1. instead of the author's name "Bernd Lauert" is displayed.
2. In the title "MRMCD" was somehow replaced by "Mrmcd" and "2015:" went missing completely
3. [The single page](https://raumzeitlabor.de/blog/mrmcd-call-for-participation/) starts with &lt;p&gt; and ends with &lt;/p&gt;

I compared to other blogposts and found that every post so far where the title contains a colon has the title in single quotation marks, so I'm testing if that makes any difference.