### PR TITLE
Don't justify type/texts

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -81,7 +81,6 @@ padding: 15px;
 background-color: #fff;
 border: 1px solid #e6e6e6;
 margin-bottom: 25px;
-text-align: justify;
 }
 
 .rzl-content img, .rzl-content object, .rzl-content iframe {
@@ -312,11 +311,4 @@ margin-top:-27%;
 
 .rzl-event-fromnow {
 	margin-bottom: 2px;
-}
-
-/* Disable text-align: justify for YouTube video archive descriptions as
- * they're usually rather short text snippets which look weird justified */
-.rzl-content #youtube-archive {
-        text-align: left; /* Internet Explorer */
-        text-align: start;
 }


### PR DESCRIPTION
Justifying type/texts on web pages is [generally](http://designforhackers.com/blog/never-justify-type-on-the-web/) a [bad](https://www.castlegateit.co.uk/2013/09/can-justified-text-be-justifed-for-the-web/) [idea](http://mrwweb.com/no-justification-dont-use-right-center-and-full-justification-on-the-web/), so we should avoid it.

The visible difference is marginal anyways on our page, but dropping the justification makes the text much neater & more pleasant to read.