### PR TITLE
Smart App Banner

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -8,6 +8,7 @@
         <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
+        <meta name="apple-itunes-app" content="app-id=968588733">
         <link rel="shortcut icon" href="/favicon.ico">
         <link rel="alternate" type="application/rss+xml" title="RaumZeitLabor RSS Feed" href="/feed.xml"/>
         <!-- build:css(app) /styles/vendor.css -->


### PR DESCRIPTION
Durch den Tag werden Safarinutzer auf iOS-Geräten auf die [RaumZeitLabor-App](https://geo.itunes.apple.com/de/app/raumzeitlabor/id968588733?mt=8&uo=6) hingewiesen.

![img_0451](https://cloud.githubusercontent.com/assets/31850/8270418/669824b8-17df-11e5-81b5-e7a601296b65.jpg)
