### PR TITLE
add nodejs-legacy to debian install list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ own environment. Choose as you like.
 
 ##### Debian
 
-    sudo apt-get install nodejs npm bundler
+    sudo apt-get install nodejs nodejs-legacy npm bundler
     sudo npm install -g grunt-cli bower
 
 ##### Arch Linux

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ own environment. Choose as you like.
 
 ##### Debian
 
-    sudo apt-get install nodejs nodejs-legacy npm bundler
+    sudo apt-get install nodejs nodejs-legacy npm bundler ruby-dev
     sudo npm install -g grunt-cli bower
 
 ##### Arch Linux


### PR DESCRIPTION
because npm is unable to find nodejs when it's called nodejs. nodejs-legacy adds a symlink /usr/bin/node -> nodejs so npm is able to find nodejs despite it being called nodejs