### PR TITLE
Agenda Button für 2016 rausnehmen

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -84,7 +84,7 @@
           <div class="container">
             <h1>RaumZeitLabor</h1>
             <p class="button-subtext">200m² Digitalkultur im Rhein-Neckar-Dreieck</p>
-            <a class="agendabutton" href="http://agendadiplom.de/">Agenda Diplom 2016<br/>ANMELDUNG</a>
+<!--            <a class="agendabutton" href="http://agendadiplom.de/">Agenda Diplom 2017<br/>ANMELDUNG</a>  -->
           </div>
           <p style="font-size: 12px; float: right;"><br/>Bild © CC-BY 2.0 <a href="https://www.flickr.com/photos/scytale/5358248726/in/photostream/">Tim Weber</a></p>
         </div>

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -67,20 +67,24 @@ color: #fff;
 
 .jumbotron .container { position:relative; }
 
-.agendabutton
-{ 
-  background: #ff0000 none repeat scroll 0 0;
-  color: #ffffff;
-  font-weight: bold;
-  line-height: 1.2;
-  padding: 5px 10px;
-  position: absolute;
-  right: 0;
-  text-align: center;
-  top: 50%;
+.agendabutton {
+    background: #ff0000 none repeat scroll 0 0;
+    border-radius: 18px;
+    color: #ffffff;
+    font-weight: 700;
+    line-height: 1.2;
+    padding: 5px 10px;
+    position: absolute;
+    right: 0;
+    text-align: center;
+    text-shadow: 1px 1px 3px #666666;
+    top: 0;
 }
-.agendabutton:hover{ color:#FFFFFF; }
 
+.agendabutton:hover {
+    background: #cc0000 none repeat scroll 0 0;
+    color: #ffffff;
+}
 
 #rzl-logo {
 height: 39px;


### PR DESCRIPTION
Ich hab mal den Agenda Diplom Button auskommentiert und auf 2017 vorbereitet.
Soweit ich weiß, sind die Termine eh schon lange ausgebucht.
Hab dann auch gleich mal runde Ecken an den Button getüdelt für nächstes Jahr.

Bitte vor dem Mergen auf OK von @pfeyffer warten
