### PR TITLE
Amazon Link rausgenommen

### DIFF
--- a/app/verein/spenden/index.html
+++ b/app/verein/spenden/index.html
@@ -61,9 +61,5 @@ Wir freuen uns über Micropayments via Flattr: [Das RaumZeitLabor auf Flattr](ht
 ### Patreon
 Auch über Patreon könnt ihr uns eine kleine Spende zukommen lassen: [Das RaumZeitLabor bei Patreon](https://www.patreon.com/raumzeitlabor)
 
-### Amazon
-Wenn ihr Amazon über diesen Link besucht, erhalten wir eine kleine Provision für alle von euch gekauften Artikel. [Amazon über Affiliatelink besuchen](http://www.amazon.de/b?node=530484031&tag=raumzeitlabor-21)
-(Eure Einkauf wird dadurch natürlich *nicht* teurer!)
-
 {% endcapture %}
 {{ c | markdownify | replace: '<dl>', '<dl class="dl-horizontal">' }}


### PR DESCRIPTION
Amazon Partnernet hat uns darauf hingewiesen, dass wir mit einem generischen Link mit unserem affiliate tag gegen die Richtlinien verstoßen.
Deshalb entferne ich den erstmal ersatzlos.