### PR TITLE
htmlmin: Ignore html files inside bower_components

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -300,7 +300,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: '<%= config.app %>',
-                    src: '**/*.html',
+                    src: ['**/*.html', '!bower_components/**/*.html'],
                     dest: '<%= config.dist %>'
                 }]
             }


### PR DESCRIPTION
This fixes the build.

The build currently fails because a current version of marked
includes a demo file with a `.html` extension but with markdown content.
htmlmin tries to minify that file but fails because it’s not actually HTML.

This change fixes that by excluding HTML files inside bower_components.

Updating other tasks to also ignore files in that subdirectory
would probably speed up the build and might make the site a bit smaller.