### PR TITLE
Add rel="me" to footer social media links

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -114,12 +114,12 @@
                     <div class="footer-group">
                     <h4>Accounts</h4>
                     <ul>
-                        <li><i class="fa fa-mastodon"></i> <a href="https://chaos.social/@RaumZeitLabor" data-category="Footer" data-event="Footer: Mastodon">Mastodon</a></li>
-                        <li><i class="fa fa-twitter"></i> <a href="https://twitter.com/raumzeitlabor" data-category="Footer" data-event="Footer: Twitter">Twitter</a></li>
-                        <li><i class="fa fa-github"></i> <a href="https://github.com/raumzeitlabor" data-category="Footer" data-event="Footer: Github">Github</a></li>
-                        <li><i class="fa fa-youtube"></i> <a href="https://www.youtube.com/user/raumzeitlabor" data-category="Footer" data-event="Footer: Youtube">Youtube</a></li>
-                        <li><i class="fa fa-instagram"></i> <a href="https://www.instagram.com/raumzeitlabor/" data-category="Footer" data-event="Footer: Instagram">Instagram</a></li>
-                        <li><i class="fa fa-flickr"></i> <a href="https://www.flickr.com/groups/rzl" data-category="Footer" data-event="Footer: Flickr">Flickr</a></li>
+                        <li><i class="fa fa-mastodon"></i> <a rel="me" href="https://chaos.social/@RaumZeitLabor" data-category="Footer" data-event="Footer: Mastodon">Mastodon</a></li>
+                        <li><i class="fa fa-twitter"></i> <a rel="me" href="https://twitter.com/raumzeitlabor" data-category="Footer" data-event="Footer: Twitter">Twitter</a></li>
+                        <li><i class="fa fa-github"></i> <a rel="me" href="https://github.com/raumzeitlabor" data-category="Footer" data-event="Footer: Github">Github</a></li>
+                        <li><i class="fa fa-youtube"></i> <a rel="me" href="https://www.youtube.com/user/raumzeitlabor" data-category="Footer" data-event="Footer: Youtube">Youtube</a></li>
+                        <li><i class="fa fa-instagram"></i> <a rel="me" href="https://www.instagram.com/raumzeitlabor/" data-category="Footer" data-event="Footer: Instagram">Instagram</a></li>
+                        <li><i class="fa fa-flickr"></i> <a rel="me" href="https://www.flickr.com/groups/rzl" data-category="Footer" data-event="Footer: Flickr">Flickr</a></li>
                         <li><i class="fa fa-tumblr"></i> <a href="https://log.raumzeitlabor.org/" data-category="Footer" data-event="Footer: Tumblr">Tumblr</a></li>
                     </ul>
                     </div>


### PR DESCRIPTION
See https://microformats.org/wiki/rel-me for context. This is primarily useful to allow account/domain verification on Mastodon, but we might as well set it for everything else.